### PR TITLE
Document Google Books API key requirement

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,12 @@
 # Use the "API Read Access Token" (long JWT), NOT the short API Key
 TMDB_TOKEN=
 
+# Google Books API key
+# Get yours at: https://console.cloud.google.com/apis/credentials
+# For this app, treat this as required for normal usage because anonymous Google Books
+# requests hit rate limits quickly and can return HTTP 429 during ordinary searching.
+GOOGLE_BOOKS_API_KEY=AIzaSyCmW-Opy00xSJ7GXk6Wd5T6kSTNkvrWspI
+
 # Port for the Express server
 PORT=3000
 

--- a/backend/docs/GOOGLE_BOOKS_API_GUIDE.md
+++ b/backend/docs/GOOGLE_BOOKS_API_GUIDE.md
@@ -65,9 +65,15 @@ http://localhost:3000
 In `backend/.env`:
 
 ```env
+GOOGLE_BOOKS_API_KEY=your_google_books_api_key
 PORT=3000
 FRONTEND_ORIGIN=http://localhost:5173
 ```
+
+`GOOGLE_BOOKS_API_KEY` should be treated as required for normal application use.
+The backend can technically call the public Google Books endpoints without a key, but in practice
+anonymous requests hit low rate limits quickly and can return HTTP `429 Too Many Requests`
+during ordinary book searching in the add-pair UI.
 
 ## How The Pieces Fit Together
 
@@ -147,4 +153,6 @@ For `/api/google-books/details`, use:
 - Google Books API logic belongs in `src/services`.
 - App setup belongs in `src/app.js`.
 - Server startup belongs in `src/server.js`.
-- No OAuth flow or API key is needed for the current backend integration.
+- No OAuth flow is needed for the current backend integration.
+- A Google Books API key should be configured in `backend/.env` for normal usage.
+- If the key is missing, book search may still work briefly, but Google can rate-limit the app with HTTP `429` responses.


### PR DESCRIPTION
## Summary
- add `GOOGLE_BOOKS_API_KEY` to the backend env example
- update the Google Books backend guide to treat the API key as effectively required for normal usage
- document the practical `429 Too Many Requests` issue seen without a configured key

## Notes
- this PR only includes documentation and sample environment updates
- the add-pair UI changes from this branch are already merged in PR #32