### PR TITLE
Scroll to top on pair detail view (closes #72)

### DIFF
--- a/frontend/app/src/pages/BookMovie.jsx
+++ b/frontend/app/src/pages/BookMovie.jsx
@@ -31,6 +31,10 @@ function BookMovie({ authenticated, authUser, onLogout }) {
   const [isBookmarking, setIsBookmarking] = useState(false);
 
   useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pair?.id]);
+
+  useEffect(() => {
     if (!pair?.id) return;
 
     const scoreUrl = `${baseUrl}/api/pairs/${encodeURIComponent(pair.id)}/score` +


### PR DESCRIPTION
## Summary
- Adds a `useEffect` in `frontend/app/src/pages/BookMovie.jsx` that calls `window.scrollTo(0, 0)` on mount and whenever `pair?.id` changes.
- Fixes the bug where opening a pair from a scrolled-down Home page would inherit the previous scroll offset and drop the user into the Comments section instead of the movie/book header.

Scope is intentionally narrow — only `BookMovie.jsx` is touched, no router-level changes. Does not overlap with #73 or #74.

Closes #72

## Test plan
- [ ] Load Home, stay near the top, click any pair card — detail view opens at the top (control case).
- [ ] Load Home, scroll far down, click a pair card in a lower row — detail view now opens at the top (was previously dropping into the Comments section).
- [ ] Repeat from several different scroll depths — each click lands at the top of the detail view.
- [ ] Navigate Home → Pair A → back → Pair B — both detail views open at the top.