### PR TITLE
Authenticate vote/score/rate from cookie, not client userId (closes #73)

### DIFF
--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -17,4 +17,19 @@ function authMiddleware(request, response, next) {
   }
 }
 
-module.exports = { authMiddleware };
+// Decodes the auth cookie if present; never rejects. Use on routes
+// that return public data but enrich the response when the caller
+// is logged in.
+function optionalAuth(request, response, next) {
+  const token = request.cookies?.[env.authCookieName];
+  if (token) {
+    try {
+      request.user = jwt.verify(token, env.jwtSecret);
+    } catch {
+      request.user = null;
+    }
+  }
+  return next();
+}
+
+module.exports = { authMiddleware, optionalAuth };

--- a/backend/src/routes/pairsRoutes.js
+++ b/backend/src/routes/pairsRoutes.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const { getPool } = require("../config/database");
-const { authMiddleware } = require("../middleware/authMiddleware");
+const { authMiddleware, optionalAuth } = require("../middleware/authMiddleware");
 
 const TMDB_GENRES = {
   28: "Action", 12: "Adventure", 16: "Animation", 35: "Comedy",
@@ -119,9 +119,10 @@ function createPairsRouter(options = {}) {
     }
   });
   
-  router.post("/:pairKey/vote", async (req, res) => {
+  router.post("/:pairKey/vote", authMiddleware, async (req, res) => {
     const { pairKey } = req.params;
-    const { userId, vote } = req.body;
+    const { vote } = req.body;
+    const userId = req.user.username;
 
     try {
       if (vote === 0) {
@@ -154,9 +155,9 @@ function createPairsRouter(options = {}) {
     }
   });
 
-  router.get("/:pairKey/score", async (req, res) => {
+  router.get("/:pairKey/score", optionalAuth, async (req, res) => {
     const { pairKey } = req.params;
-    const { userId } = req.query;
+    const userId = req.user?.username ?? "";
 
     try {
       const [[{ score }]] = await database().query(
@@ -164,11 +165,9 @@ function createPairsRouter(options = {}) {
         [pairKey]
       );
 
-      
-
       const [[userRow]] = await database().query(
         `SELECT vote, book_rating, movie_rating, bookmarked FROM pair_data.pair_votes WHERE user_name = ? AND pair_id = ?`,
-        [userId ?? "", pairKey]
+        [userId, pairKey]
       );
 
       // Average ratings across all users (ignoring zeros/unrated)
@@ -194,13 +193,10 @@ function createPairsRouter(options = {}) {
     }
   });
 
-  router.post("/:pairKey/rate", async (req, res) => {
+  router.post("/:pairKey/rate", authMiddleware, async (req, res) => {
     const { pairKey } = req.params;
-    const { userId, bookRating, movieRating } = req.body;
-
-    if (!userId) {
-      return res.status(400).json({ error: "userId is required." });
-    }
+    const { bookRating, movieRating } = req.body;
+    const userId = req.user.username;
 
     try {
       await database().query(

--- a/frontend/app/src/pages/BookMovie.jsx
+++ b/frontend/app/src/pages/BookMovie.jsx
@@ -33,9 +33,8 @@ function BookMovie({ authenticated, authUser, onLogout }) {
   useEffect(() => {
     if (!pair?.id) return;
 
-    const scoreUrl = `${baseUrl}/api/pairs/${encodeURIComponent(pair.id)}/score` +
-      (authUser?.username ? `?userId=${encodeURIComponent(authUser.username)}` : "");
-    fetch(scoreUrl)
+    const scoreUrl = `${baseUrl}/api/pairs/${encodeURIComponent(pair.id)}/score`;
+    fetch(scoreUrl, { credentials: "include" })
       .then(r => r.json())
       .then(data => {
         setScore(data.score);
@@ -70,10 +69,10 @@ function BookMovie({ authenticated, authUser, onLogout }) {
   try {
     const response = await fetch(`${baseUrl}/api/pairs/${encodeURIComponent(pair.id)}/vote`, {
       method: "POST",
+      credentials: "include",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         vote: vote === userVote ? 0 : vote,
-        userId: authUser?.username
       }),
     });
 
@@ -100,9 +99,9 @@ function BookMovie({ authenticated, authUser, onLogout }) {
     try {
       const res = await fetch(`${baseUrl}/api/pairs/${encodeURIComponent(pair.id)}/rate`, {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          userId: authUser?.username,
           movieRating: type === "movie" ? rating : movieRating,
           bookRating: type === "book" ? rating : bookRating,
         }),


### PR DESCRIPTION
## Summary
The `/:pairKey/vote`, `/:pairKey/score`, and `/:pairKey/rate` endpoints in `backend/src/routes/pairsRoutes.js` previously trusted a `userId` field supplied by the client. That allowed any caller to read another user's private vote / personal ratings / bookmark status, or write votes and ratings on behalf of another user — a Broken Access Control / IDOR vulnerability matching the pattern flagged in #73.

This PR removes that trust:

- New `optionalAuth` middleware in `authMiddleware.js`: decodes the JWT cookie if present, never rejects. Used for routes that return public data but enrich the response when the caller is logged in.
- `/vote` and `/rate` now require `authMiddleware` and derive `userId` from `req.user.username`. The body's `userId` field is no longer read.
- `/score` now uses `optionalAuth`. When the caller is logged in, user-specific fields (`userVote`, `bookRating`, `movieRating`, `bookmarked`) reflect their own state from the cookie identity; otherwise those fields fall back to defaults.
- `BookMovie.jsx` drops the `userId` payload from vote and rate requests, drops the `?userId=...` query string from the score URL, and adds `credentials: "include"` to all three fetches so the cookie is actually sent.

The comment edit/delete endpoints already enforce ownership via `WHERE id = ? AND username = ?` and were not vulnerable.

Scope is limited to the three endpoints and their callers in `BookMovie.jsx`. Does not overlap with #74.

Closes #73

## Test plan
- [ ] Logged-out user opens a pair detail page: score loads, average ratings render, but personal vote / personal rating / bookmark indicators stay neutral.
- [ ] Logged-in user opens a pair detail page: their previous vote, personal ratings, and bookmark status render correctly.
- [ ] Logged-in user upvotes / downvotes / clears a vote — score updates, the up/down arrow fills correctly.
- [ ] Logged-in user submits a star rating — average rating updates.
- [ ] Logged-out user attempts to vote or rate — receives a 403 from the backend (frontend already gates this with the "must be logged in" alert, so the network request shouldn't fire under normal use).
- [ ] Manual IDOR check (curl): `POST /:pairKey/vote` with `userId: "someoneElse"` in the body and no auth cookie returns 403; with a valid cookie, the vote is recorded against the cookie's identity, not the body's `userId`.