### PR TITLE
Make Rating component keyboard-accessible (closes #74)

### DIFF
--- a/frontend/app/src/components/Rating.jsx
+++ b/frontend/app/src/components/Rating.jsx
@@ -17,8 +17,15 @@ function Rating({ value = 0, onChange }) {
     return "0%";
   };
 
+  const handleKeyDown = (e, star) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onChange?.(star);
+    }
+  };
+
   return (
-    <div className="stars">
+    <div className="stars" role="radiogroup" aria-label="Rating">
       {[1, 2, 3, 4, 5].map((star) => {
         const fill = getFill(star);
 
@@ -26,9 +33,16 @@ function Rating({ value = 0, onChange }) {
           <span
             key={star}
             className="star"
+            role="radio"
+            aria-label={`${star} star${star === 1 ? "" : "s"}`}
+            aria-checked={value >= star}
+            tabIndex={0}
             onMouseMove={(e) => setHoverRating(getStarValue(e, star))}
             onMouseLeave={() => setHoverRating(null)}
+            onFocus={() => setHoverRating(star)}
+            onBlur={() => setHoverRating(null)}
             onClick={(e) => onChange?.(getStarValue(e, star))}
+            onKeyDown={(e) => handleKeyDown(e, star)}
             style={{
               backgroundImage: `linear-gradient(to right, var(--medium-purple) ${fill}, gray ${fill})`,
               backgroundClip: "text",


### PR DESCRIPTION
## Summary
The star spans in `frontend/app/src/components/Rating.jsx` had `onClick` handlers but no keyboard equivalent, failing the `jsx-a11y/click-events-have-key-events` lint rule and leaving the rating system unusable for keyboard and assistive-tech users.

- Each star now has `tabIndex={0}`, `role="radio"`, `aria-label` (e.g. "3 stars"), and `aria-checked` reflecting the current rating.
- The container is now `role="radiogroup"` with `aria-label="Rating"`.
- New `onKeyDown` handler triggers `onChange` on Enter or Space, setting the focused star's whole value.
- Focusing a star previews the fill the same way mouse hover does.

Mouse interaction (including half-star precision via click X-coordinate) is unchanged.

**Known limitation:** keyboard input sets whole-star values only (1–5). Half-star precision (0.5, 1.5, …) remains mouse-only. WCAG does not require identical input precision across modalities; arrow-key half-step support is a reasonable follow-up if needed.

Scope is limited to `Rating.jsx`. Does not overlap with #73.

Closes #74

## Test plan
- [ ] Mouse: hover left half / right half of any star → fill preview reflects 0.5 vs 1.0; clicking saves the corresponding rating.
- [ ] Keyboard: Tab cycles through all 10 stars (5 movie + 5 book); each focused star shows the same fill preview as mouse hover.
- [ ] Keyboard: Enter or Space on a focused star saves that star's whole value; reloading the page shows the saved rating persisted.
- [ ] Keyboard: other keys (arrows, letters, Esc) on a focused star do nothing.
- [ ] Tabbing away from the stars clears the focus-preview fill.
- [ ] DevTools inspection confirms `role="radio"`, `aria-label`, `aria-checked`, and `tabIndex="0"` on each star, and `role="radiogroup"` on the container.
- [ ] `npx eslint src/components/Rating.jsx` reports no warnings (the original `click-events-have-key-events` warning is gone).