### PR TITLE
View other users' profiles from comment usernames

### DIFF
--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -47,38 +47,7 @@ function createUserRouter() {
 
   router.get("/bookmarks", authMiddleware, async (request, response) => {
     try {
-      const [rows] = await getPool().execute(
-        `SELECT p.*
-        FROM pair_data.movie_book_pairs p
-        JOIN pair_data.pair_votes pv ON pv.pair_id = p.id
-        WHERE pv.user_name = ? AND pv.bookmarked = 1
-        ORDER BY pv.movie_rating DESC, pv.book_rating DESC, p.id DESC`,
-        [request.user.username]
-      );
-      
-      const bookmarks = rows.map(row => ({
-        id: row.id,
-        user: row.user,
-        score: row.score,
-        movie: {
-          id: row.movie_id,
-          title: row.movie_title,
-          poster_path: row.movie_poster_path,
-          release_date: row.movie_release_date,
-          overview: row.movie_overview,
-          genre: row.movie_genre,
-          type: row.movie_type,
-        },
-        book: {
-          id: row.book_id,
-          title: row.book_title,
-          thumbnail: row.book_thumbnail,
-          publishedDate: row.book_publishedDate,
-          description: row.book_description,
-          categories: row.book_categories,
-          pagecount: row.book_pagecount,
-        },
-      }));
+      const bookmarks = await fetchBookmarksFor(request.user.username);
       response.json({ ok: true, bookmarks });
     } catch (error) {
       console.error("DB error:", error);
@@ -86,7 +55,69 @@ function createUserRouter() {
     }
   });
 
+  // Public profile view: anyone authenticated can fetch another user's
+  // public-facing fields. Writes still go through the cookie-only
+  // /bio and /pfp endpoints — never through this read path.
+  router.get("/:username/profile", authMiddleware, async (request, response) => {
+    try {
+      const { username } = request.params;
+      const [rows] = await getPool().execute(
+        'SELECT username, pfp_index, bio FROM authdb.users WHERE username = ? LIMIT 1',
+        [username]
+      );
+      const user = rows[0];
+      if (!user) {
+        return response.status(404).json({ error: "User not found." });
+      }
+      const bookmarks = await fetchBookmarksFor(user.username);
+      response.json({
+        ok: true,
+        username: user.username,
+        pfp_index: user.pfp_index ?? 0,
+        bio: user.bio ?? "",
+        bookmarks,
+      });
+    } catch (error) {
+      console.error("DB error:", error);
+      response.status(500).json({ error: error.message });
+    }
+  });
+
   return router;
+}
+
+async function fetchBookmarksFor(username) {
+  const [rows] = await getPool().execute(
+    `SELECT p.*
+    FROM pair_data.movie_book_pairs p
+    JOIN pair_data.pair_votes pv ON pv.pair_id = p.id
+    WHERE pv.user_name = ? AND pv.bookmarked = 1
+    ORDER BY pv.movie_rating DESC, pv.book_rating DESC, p.id DESC`,
+    [username]
+  );
+  return rows.map(row => ({
+    id: row.id,
+    user: row.user,
+    score: row.score,
+    movie: {
+      id: row.movie_id,
+      title: row.movie_title,
+      poster_path: row.movie_poster_path,
+      release_date: row.movie_release_date,
+      overview: row.movie_overview,
+      genre: row.movie_genre,
+      type: row.movie_type,
+    },
+    book: {
+      id: row.book_id,
+      title: row.book_title,
+      thumbnail: row.book_thumbnail,
+      publishedDate: row.book_publishedDate,
+      description: row.book_description,
+      categories: row.book_categories,
+      pagecount: row.book_pagecount,
+    },
+  }));
 }
 
 module.exports = { createUserRouter };

--- a/frontend/app/src/App.jsx
+++ b/frontend/app/src/App.jsx
@@ -117,6 +117,14 @@ function App() {
           }
         />
         <Route
+          path="/user/:username"
+          element={
+            <ProtectedRoute authenticated={authenticated} checkingAuth={checkingAuth}>
+              <User authUser={authUser} onLogout={handleLogout} setAuthUser={setAuthUser} />
+            </ProtectedRoute>
+          }
+        />
+        <Route
           path="/BookMovie"
           element={
             <BookMovie

--- a/frontend/app/src/pages/BookMovie.jsx
+++ b/frontend/app/src/pages/BookMovie.jsx
@@ -416,9 +416,21 @@ function BookMovie({ authenticated, authUser, onLogout }) {
             <div key={comment.id} style={{ background: '#333', borderRadius: '8px', padding: '10px 14px' }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <div>
-                  <span style={{ color: 'var(--medium-purple)', fontWeight: 'bold', fontSize: '13px' }}>
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/user/${encodeURIComponent(comment.username)}`)}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      padding: 0,
+                      cursor: 'pointer',
+                      color: 'var(--medium-purple)',
+                      fontWeight: 'bold',
+                      fontSize: '13px',
+                    }}
+                  >
                     {comment.username}
-                  </span>
+                  </button>
                   <span style={{ color: '#aaa', fontSize: '11px', marginLeft: '10px' }}>
                     {new Date(comment.created_at).toLocaleDateString()}
                   </span>

--- a/frontend/app/src/pages/User.jsx
+++ b/frontend/app/src/pages/User.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import BookFlix_logo_cropped from '../assets/BookFlix_logo_cropped_bg_removed.png';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const baseUrl = import.meta.env.VITE_API_BASE ?? "http://localhost:3000";
 const pics = import.meta.glob('../assets/profile_pics/*.png', { eager: true });
@@ -10,25 +10,47 @@ const profilePicSources = Object.values(pics).map(pic => pic.default);
 
 function User({ authUser, onLogout, setAuthUser }) {
   const navigate = useNavigate();
-  const [pfp_index, setPfpIndex] = useState(authUser?.pfp_index ?? 0);
+  const { username: paramUsername } = useParams();
+  const isSelf = !paramUsername || paramUsername === authUser?.username;
+  const displayUsername = isSelf ? (authUser?.username ?? "Unknown user") : paramUsername;
+
+  const [otherPfpIndex, setOtherPfpIndex] = useState(0);
+  const pfp_index = isSelf ? (authUser?.pfp_index ?? 0) : otherPfpIndex;
   const [bio, setBio] = useState("");
   const bioRef = useRef(null);
   const [bookmarks, setBookmarks] = useState([]);
+  const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {
-    fetch(`${baseUrl}/api/users/bio`, { credentials: "include" })
-      .then(r => r.json())
-      .then(data => {
-        setBio(data.bio ?? "");
-        if (bioRef.current) bioRef.current.innerText = data.bio || "Click here to edit your bio";
-      })
-      .catch(err => console.error("Failed to load bio:", err));
+    if (isSelf) {
+      fetch(`${baseUrl}/api/users/bio`, { credentials: "include" })
+        .then(r => r.json())
+        .then(data => {
+          setBio(data.bio ?? "");
+          if (bioRef.current) bioRef.current.innerText = data.bio || "Click here to edit your bio";
+        })
+        .catch(err => console.error("Failed to load bio:", err));
 
-    fetch(`${baseUrl}/api/users/bookmarks`, { credentials: "include" })
-      .then(r => r.json())
-      .then(data => setBookmarks(data.bookmarks ?? []))
-      .catch(err => console.error("Failed to load bookmarks:", err));
-  }, []);
+      fetch(`${baseUrl}/api/users/bookmarks`, { credentials: "include" })
+        .then(r => r.json())
+        .then(data => setBookmarks(data.bookmarks ?? []))
+        .catch(err => console.error("Failed to load bookmarks:", err));
+    } else {
+      fetch(`${baseUrl}/api/users/${encodeURIComponent(paramUsername)}/profile`, { credentials: "include" })
+        .then(async r => {
+          if (r.status === 404) { setNotFound(true); return null; }
+          setNotFound(false);
+          return r.json();
+        })
+        .then(data => {
+          if (!data) return;
+          setBio(data.bio ?? "");
+          setOtherPfpIndex(data.pfp_index ?? 0);
+          setBookmarks(data.bookmarks ?? []);
+        })
+        .catch(err => console.error("Failed to load profile:", err));
+    }
+  }, [isSelf, paramUsername]);
 
   const handleSaveBio = async (e) => {
     const newBio = e.currentTarget.innerText.trim();
@@ -50,7 +72,7 @@ function User({ authUser, onLogout, setAuthUser }) {
 
   const handleCyclePfp = async () => {
     const nextIndex = (pfp_index + 1) % profilePicSources.length;
-    setPfpIndex(nextIndex);
+    setAuthUser(prev => ({ ...prev, pfp_index: nextIndex }));
 
     try {
       await fetch(`${baseUrl}/api/users/pfp`, {
@@ -61,7 +83,6 @@ function User({ authUser, onLogout, setAuthUser }) {
         },
         body: JSON.stringify({ pfp_index: nextIndex }),
       });
-      setAuthUser(prev => ({ ...prev, pfp_index: nextIndex }));
     } catch (error) {
       console.error("Error updating profile picture:", error);
     }
@@ -87,25 +108,34 @@ function User({ authUser, onLogout, setAuthUser }) {
         </div>
       </div>
 
-        <h1>User Profile Page</h1>
-        
+        <h1>{isSelf ? "User Profile Page" : `${displayUsername}'s Profile`}</h1>
+
+        {notFound ? (
+          <p style={{ textAlign: 'center', color: '#aaa' }}>User not found.</p>
+        ) : (
         <div className="user-grid">
-            <div className="profile-pic"> 
+            <div className="profile-pic">
                 <img src={profilePicSources[pfp_index]} alt="Profile"></img>
             </div>
-            <button onClick={handleCyclePfp} className="cycle_pfp_btn">
-              Next Profile Picture
-            </button>
+            {isSelf && (
+              <button onClick={handleCyclePfp} className="cycle_pfp_btn">
+                Next Profile Picture
+              </button>
+            )}
 
-            <div className="username">{authUser?.username ?? "Unknown user"}</div>
+            <div className="username">{displayUsername}</div>
 
             <div className="bio">
               <div style={{ color: 'var(--medium-purple)' }}>Bio</div>
-              <div className="bio-text" ref={bioRef} contentEditable suppressContentEditableWarning={true} onFocus={(e) => {
-                if (e.currentTarget.innerText === "Click here to edit your bio") { e.currentTarget.innerText = "";}}}
-                onBlur={(e) => { if (e.currentTarget.innerText.trim() === "") {e.currentTarget.innerText = "Click here to edit your bio";} handleSaveBio(e); }}>
-                Click here to edit your bio
-              </div>
+              {isSelf ? (
+                <div className="bio-text" ref={bioRef} contentEditable suppressContentEditableWarning={true} onFocus={(e) => {
+                  if (e.currentTarget.innerText === "Click here to edit your bio") { e.currentTarget.innerText = "";}}}
+                  onBlur={(e) => { if (e.currentTarget.innerText.trim() === "") {e.currentTarget.innerText = "Click here to edit your bio";} handleSaveBio(e); }}>
+                  Click here to edit your bio
+                </div>
+              ) : (
+                <div className="bio-text">{bio || <span style={{ color: '#aaa' }}>No bio yet.</span>}</div>
+              )}
             </div>
 
             <div className="bookmarks">
@@ -126,6 +156,7 @@ function User({ authUser, onLogout, setAuthUser }) {
             </div>
 
         </div>
+        )}
 
     </div>
   );


### PR DESCRIPTION
## Summary
Comment usernames on the pair detail view are now clickable and open a read-only view of that user's public profile (pfp, bio, bookmarks).

### Backend
- New `GET /api/users/:username/profile` route in `userRoutes.js`, auth-gated, returns `{ username, pfp_index, bio, bookmarks }`. Returns 404 for unknown users.
- The existing `/bio`, `/pfp`, `/bookmarks` endpoints are unchanged — they remain cookie-only and derive identity from `req.user.username`. **No write path on the new route**; writes never accept a username from the URL or body, so the IDOR fix from #73 is preserved.
- Bookmarks query factored into a shared `fetchBookmarksFor(username)` helper used by both `/bookmarks` and `/:username/profile`.

### Frontend
- `App.jsx`: new `/user/:username` route, wrapped in `ProtectedRoute` (browsing requires login).
- `User.jsx` branches on `useParams().username`:
  - Self (no param OR param === `authUser.username`) → existing editable view, unchanged.
  - Other user → fetches `/api/users/:username/profile`, renders pfp + bio as plain text, hides the "Next Profile Picture" button and the editable bio. Shows "User not found." on 404.
  - Pfp index for self is now derived from `authUser.pfp_index` rather than a separate local state, so the cycle button keeps instant feedback via `setAuthUser`.
- `BookMovie.jsx`: comment username spans are now `<button>`s that navigate to `/user/<encoded username>`. Visual styling matches the previous purple bold span; cursor changes to pointer on hover.

### Decisions locked in
1. `/user/:username` is auth-gated (ProtectedRoute) — limits anonymous enumeration.
2. Bookmarks are visible on others' profiles.
3. Clicking your own name in a comment lands you on the editable self view.

## Security model
| Concern | Mitigation |
|---|---|
| Editing someone else's bio / pfp | Writes still go through `/api/users/bio` and `/api/users/pfp`, both `authMiddleware` + `req.user.username`. The new route has no write surface. |
| Reading sensitive fields | `SELECT username, pfp_index, bio` is an explicit allowlist — no `password_hash` / no `SELECT *`. |
| Username injection | Frontend `encodeURIComponent`; backend SQL is parameterized. |
| User enumeration | Browsing requires login; usernames are already public via comments. 404 vs 200 doesn't add new disclosure. |
| IDOR regressions from the #73 pattern | New route accepts no `userId` from query/body; identity for reads comes from path, identity for writes still comes only from cookie. |

## Test plan
- [ ] Logged-out: visiting `/user/CameronIsAwesome` redirects to login.
- [ ] Logged-in: clicking another user's name in a comment opens `/user/<that user>` and shows their pfp, bio, bookmarks. No edit buttons. Bio is plain text.
- [ ] Bookmarks card on a foreign profile opens the corresponding pair page (existing flow).
- [ ] Clicking your own name in a comment lands you on `/user/<self>` with the *editable* view (cycle pfp button visible, bio is contentEditable).
- [ ] Visiting `/user/totally-fake` directly renders "User not found."
- [ ] Backend: `GET /api/users/CameronIsAwesome/profile` with cookie returns 200 and the expected payload (one bookmark: One-Punch Man pair). Without cookie returns 403.
- [ ] Backend: `POST /api/users/anyOtherUser/profile` returns 404 (no write handler exists). `POST /api/users/bio` while authenticated still updates only your own bio regardless of any path/body username.
- [ ] ESLint clean on the four touched files.